### PR TITLE
Remove detail modal description text

### DIFF
--- a/app.js
+++ b/app.js
@@ -293,8 +293,7 @@ const renderResults = () => {
 
   const detailSummary = `
     <div class="detail-summary">
-      <p><strong>Animal resultante:</strong> ${style.title}</p>
-      <p><strong>Descripción:</strong> ${style.description}</p>
+      <p><strong>Resultado:</strong> ${style.title}</p>
       <p><strong>Totales por estilo:</strong> S = ${scores.S} | C = ${scores.C} | D = ${scores.D} | I = ${scores.I}</p>
       <p><strong>Cálculo vertical (S - C):</strong> ${scores.S} - ${scores.C} = ${vertical}</p>
       <p><strong>Cálculo horizontal (D - I):</strong> ${scores.D} - ${scores.I} = ${horizontal}</p>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <main class="app-shell">
       <header class="app-header">
         <h1>Test de Alessandra</h1>
-        <p class="subtitle">Descubrí tu animal representativo.</p>
       </header>
 
       <section id="welcome-screen" class="card active">


### PR DESCRIPTION
## Summary
- stop rendering the style description inside the results detail modal
- show the animal result using the required "Resultado" label while keeping the remaining metrics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d450441afc8329941103ce161214cd